### PR TITLE
Adds elk playbook & cleans up keep playbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Set of ansible playbooks for deploying, monitoring and managing KEEP validator i
 * Ubuntu Server setup with a sudo-enabled user to operate ansible tasks.
     * Support for other OS families scoped.
 
+<br />
 
-# Configuration
+# KEEP Configuration
 ## Step 1
 Change the ./vars/vars.yaml varaiables configuration file accordingly.
 
@@ -41,16 +42,41 @@ Once you've bootstrapped and you want to deploy a configuration change. You can 
 ansible-playbook configure_keep.yaml -i hosts -K
 ```
 
+<br />
+
+# Configuring ELK (Experimental)
+## Step 1
+Create your own Elastic Cloud deployment. Follow the steps [here](https://www.notion.so/Setting-up-Elastic-Stack-Dashboard-14f9edc94418468bb95af40417a0332a)
+
+## Step 2
+Change the ./vars/elk_vars.yaml variables configuration file accordingly.
+
+## Step 3
+Install the ansible role dependencies from galaxy:
+```bash
+ansible-galaxy install geerlingguy.java geerlingguy.logstash geerlingguy.filebeat
+```
+
+# Usage
+
+Execute the ELK Playbook:
+```bash
+ansible-playbook bootstrap_elk.yaml -i hosts -K
+```
+
+
 ## Playbooks
 yaml | Description
 -----|------------
 `bootstrap_keep.yaml` | Installs & configures  [Keep-ecdsa](https://github.com/keep-network/keep-ecdsa) and [Keep-core](https://github.com/keep-network/keep-core/blob/master/docs/run-random-beacon.adoc)
 `configure_keep.yaml` | Applies configuration changes and restarts Keep-ecdsa & Keep-core
+`bootstrap_elk.yaml` | Installs filebeat+logstash and ingests KEEP logs to ELK
 
 ## Future plans 🚀:
 - [x] Provisioning of docker and other related dependencies.
 - [x] Deploys and executes Keep-client and Keep-ecdsa-client docker instances
 - [X] Compartmentalize sets of tasks and provide greater non-linear control.
+- [ ] Resume on restart configuration. (service)
 - [ ] Better security and secrets handling (Ansible Vaults)
 - [ ] Cross-OS compatibility for docker-setup role
-- [ ] Deployment of filebeat configurations for Log Monitoring using [ElasticStack](https://www.notion.so/Setting-up-Elastic-Stack-Dashboard-14f9edc94418468bb95af40417a0332a))
+- [X] Deployment of filebeat configurations for Log Monitoring using [ElasticStack](https://www.notion.so/Setting-up-Elastic-Stack-Dashboard-14f9edc94418468bb95af40417a0332a))

--- a/bootstrap_elk.yaml
+++ b/bootstrap_elk.yaml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: yes
+
+  vars_files:
+    - vars/elk_vars.yaml
+
+  pre_tasks:
+    - name: Update apt cache if needed.
+      apt: update_cache=yes cache_valid_time=86400
+
+  roles:
+    - elk-cloud

--- a/bootstrap_keep.yaml
+++ b/bootstrap_keep.yaml
@@ -10,8 +10,10 @@
     - common
     - role: docker-setup
       become: yes
-    - keep-client
-    - keep-ecdsa
+    - role: keep-client
+      become: yes
+    - role: keep-ecdsa
+      become: yes
 
   tasks:        
     - block:
@@ -52,7 +54,7 @@
           restart: yes
           command: --config /mnt/keep-ecdsa/config/config.toml start
           entrypoint:
-            - /usr/local/bin/keep-ecdsa 
+            - /usr/local/bin/keep-ecdsa
           volumes:
             - "{{ '/home/{0}/keep-ecdsa:/mnt/keep-ecdsa'.format(username) }}"
             - "{{ '/home/{0}/keep-ecdsa/logs:/var/log/keep'.format(username) }}"
@@ -65,6 +67,7 @@
           env:
             LOG_LEVEL: info
             KEEP_ETHEREUM_PASSWORD: "{{ account.password }}"
+            IPFS_LOGGING_FMT: nocolor
             GOLOG_FILE: "/var/log/keep/keep.log"
             GOLOG_TRACING_FILE: "/var/log/keep/trace.json"
       rescue:

--- a/configure_keep.yaml
+++ b/configure_keep.yaml
@@ -50,7 +50,7 @@
           restart: yes
           command: --config /mnt/keep-ecdsa/config/config.toml start
           entrypoint:
-            - /usr/local/bin/keep-ecdsa 
+            - /usr/local/bin/keep-ecdsa
           volumes:
             - "{{ '/home/{0}/keep-ecdsa:/mnt/keep-ecdsa'.format(username) }}"
             - "{{ '/home/{0}/keep-ecdsa/logs:/var/log/keep'.format(username) }}"
@@ -63,6 +63,7 @@
           env:
             LOG_LEVEL: info
             KEEP_ETHEREUM_PASSWORD: "{{ account.password }}"
+            IPFS_LOGGING_FMT: nocolor
             GOLOG_FILE: "/var/log/keep/keep.log"
             GOLOG_TRACING_FILE: "/var/log/keep/trace.json"
       rescue:

--- a/roles/elk-cloud/meta/main.yaml
+++ b/roles/elk-cloud/meta/main.yaml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - role: geerlingguy.java
+  - role: geerlingguy.logstash
+  - role: geerlingguy.filebeat

--- a/roles/elk-cloud/tasks/main.yaml
+++ b/roles/elk-cloud/tasks/main.yaml
@@ -1,0 +1,13 @@
+---
+- name: Overwrite Logstash configuration files.
+  template:
+    src: "{{ item }}.j2"
+    dest: "/etc/logstash/conf.d/{{ item }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - 01-beats-input.conf
+    - 20-keep-filter.conf
+    - 30-elasticsearch-output.conf
+  notify: restart logstash

--- a/roles/elk-cloud/templates/01-beats-input.conf.j2
+++ b/roles/elk-cloud/templates/01-beats-input.conf.j2
@@ -1,0 +1,12 @@
+input {
+  beats {
+    port => {{ logstash_listen_port_beats }}
+{% if logstash_ssl_certificate_file and logstash_ssl_key_file %}
+    ssl => true
+    ssl_certificate => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
+    ssl_key => "{{ logstash_ssl_dir }}/{{ logstash_ssl_key_file | basename }}"
+    ssl_verify_mode => "peer"
+    ssl_certificate_authorities => "{{ logstash_ssl_dir }}/{{ logstash_ssl_certificate_file | basename }}"
+{% endif %}
+  }
+}

--- a/roles/elk-cloud/templates/20-keep-filter.conf.j2
+++ b/roles/elk-cloud/templates/20-keep-filter.conf.j2
@@ -1,0 +1,49 @@
+filter {
+  if [log][file][path] == "{{ keepclient_logs }}" {
+    grok {
+      patterns_dir => "./patterns"
+      match => { "message" => "%{TIMESTAMP_ISO8601} %{LOGLEVEL} %{NOTSPACE:module} %{JAVACLASS}:%{INT:line_number}: number of connected peers: \[%{INT:peer_count}\]%{GREEDYDATA:message}"}
+      remove_tag => ["_grokparsefailure"]
+      add_field => { "subType" => "total_peers" }
+      remove_tag => ["_grokparsefailure"]
+    }
+    if "_grokparsefailure" in [tags] {
+      grok {
+        patterns_dir => "./patterns"
+        match => { "message" => "%{TIMESTAMP_ISO8601} %{LOGLEVEL} %{NOTSPACE:module} %{JAVACLASS}:%{INT:line_number}: %{GREEDYDATA:message}" }
+        add_field => { "subType" => "all" }
+        remove_tag => ["_grokparsefailure"]
+      }
+    }
+    mutate {
+      convert => {
+        "peer_count" => "integer"
+      }
+    }
+  }
+}
+
+filter {
+  if [log][file][path] == "{{ keepecdsa_logs }}" {
+    grok {
+      patterns_dir => "./patterns"
+      match => { "message" => "%{TIMESTAMP_ISO8601}%{SPACE}%{LOGLEVEL}%{SPACE}%{NOTSPACE:module}%{SPACE}number of connected peers: \[%{INT:peer_count}\]%{GREEDYDATA:message}"}
+      remove_tag => ["_grokparsefailure"]
+      add_field => { "subType" => "total_peers" }
+      remove_tag => ["_grokparsefailure"]
+    }
+    if "_grokparsefailure" in [tags] {
+      grok {
+        patterns_dir => "./patterns"
+        match => { "message" => "%{TIMESTAMP_ISO8601} %{SPACE} %{LOGLEVEL} %{SPACE} %{GREEDYDATA:message}" }
+        add_field => { "subType" => "all" }
+        remove_tag => ["_grokparsefailure"]
+      }
+    }
+    mutate {
+      convert => {
+        "peer_count" => "integer"
+      }
+    }
+  }
+}

--- a/roles/elk-cloud/templates/30-elasticsearch-output.conf.j2
+++ b/roles/elk-cloud/templates/30-elasticsearch-output.conf.j2
@@ -1,0 +1,8 @@
+output {
+  elasticsearch {
+    hosts => {{ elasticsearch_hosts | to_json }}
+    index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    user => "elastic"
+    password => "{{ elasticsearch_pw }}"
+  }
+}

--- a/vars/elk_vars.yaml
+++ b/vars/elk_vars.yaml
@@ -1,0 +1,20 @@
+---
+java_packages:
+  - openjdk-8-jdk
+
+keepclient_logs: /home/keep/keep-client/logs/keep.log
+keepecdsa_logs: /home/keep/keep-ecdsa/logs/keep.log
+
+filebeat_inputs:
+  - type: log
+    paths:
+      - /var/log/auth.log
+      - /home/keep/keep-client/logs/keep.log
+      - /home/keep/keep-ecdsa/logs/keep.log
+
+elasticsearch_hosts:
+  - https://XXXXXXXXXXXXXXXXXXXXXX:9243
+
+elasticsearch_pw: XXXXXXXXXXXXXXXXXXXXX
+
+logstash_listen_port_beats: 5044


### PR DESCRIPTION
The bootstrap_elk playbook installs and configures Logstash & Filebeat on the host instance and configures as such for KEEP logs to be ingested to a specified Elasticsearch host.