### PR TITLE
New monitoring for grafana/prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Set of ansible playbooks for deploying, monitoring and managing KEEP validator i
 * Ansible
     * [Install Guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 * Ubuntu Server setup with a sudo-enabled user to operate ansible tasks.
-    * Support for other OS families scoped.
-
+* The appropriate firewall configuration settings.
 <br />
 
 # KEEP Configuration
@@ -34,15 +33,43 @@ Execute the bootstrap playbook providing the required components and entering us
 ansible-playbook bootstrap_keep.yaml -i hosts -K
 ```
 
-After successfully setting up keep instances, explore the other additional playbooks:
+After successfully setting up keep instances, explore the other additional playbooks for setting up monitoring.
 
-## Additionally...
-Once you've bootstrapped and you want to deploy a configuration change. You can run the configure_keep.yaml playbook:
- ```bash
+
+<br /><br />
+
+# Configuring Promethus/Grafana Monitoring
+The playbooks configure in the same manner as in mutedtommy's guide found here:
+
+https://medium.com/@hr12rtk/keep-random-beacon-node-monitoring-grafana-prometheus-and-loki-4a4b669b31ea
+
+## Step 1
+Install the ansible role dependencies from galaxy:
+```bash
+ansible-galaxy install community.general
+```
+
+## Step 2
+Install and configure the monitoring software using the bootstrap_monitoring playbook
+```bash
+ansible-playbook bootstrap_monitoring.yaml -i hosts -K
+```
+
+## Step 3
+SSH in and run the docker-compose command in the following two directories:
+- /home/ansible/prometheus/
+- /home/ansible/loki/
+```bash
+sudo docker-compose up -d
+```
+
+## Step 4
+Reconfigure and re-run docker image(s) to configure docker to use loki log driver for monitoring.
+```bash
 ansible-playbook configure_keep.yaml -i hosts -K
 ```
 
-<br />
+<br /><br />
 
 # Configuring ELK (Experimental)
 ## Step 1
@@ -64,19 +91,18 @@ Execute the ELK Playbook:
 ansible-playbook bootstrap_elk.yaml -i hosts -K
 ```
 
+<br /><br />
 
 ## Playbooks
 yaml | Description
 -----|------------
 `bootstrap_keep.yaml` | Installs & configures  [Keep-ecdsa](https://github.com/keep-network/keep-ecdsa) and [Keep-core](https://github.com/keep-network/keep-core/blob/master/docs/run-random-beacon.adoc)
-`configure_keep.yaml` | Applies configuration changes and restarts Keep-ecdsa & Keep-core
+`configure_keep.yaml` | Adds additional loki & monitoring configuration when running docker instance(s)
+`bootstrap_monitoring` | Installs and configures grafana and prometheus for monitoring.
 `bootstrap_elk.yaml` | Installs filebeat+logstash and ingests KEEP logs to ELK
 
-## Future plans 🚀:
-- [x] Provisioning of docker and other related dependencies.
-- [x] Deploys and executes Keep-client and Keep-ecdsa-client docker instances
-- [X] Compartmentalize sets of tasks and provide greater non-linear control.
-- [ ] Resume on restart configuration. (service)
-- [ ] Better security and secrets handling (Ansible Vaults)
-- [ ] Cross-OS compatibility for docker-setup role
-- [X] Deployment of filebeat configurations for Log Monitoring using [ElasticStack](https://www.notion.so/Setting-up-Elastic-Stack-Dashboard-14f9edc94418468bb95af40417a0332a))
+<br />
+
+## Additional tasks you should consider:
+- Configuring email alerts via Grafana
+- Automating a backup procedure of managed keys for ECDSA.

--- a/bootstrap_monitoring.yaml
+++ b/bootstrap_monitoring.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: yes
+
+  roles:
+    - monitoring

--- a/configure_keep.yaml
+++ b/configure_keep.yaml
@@ -15,6 +15,20 @@
 
   tasks:        
     - block:
+      - name: Stop keep-client container
+        become: yes
+        ignore_errors: yes
+        community.general.docker_container:
+          name: keep-client
+          state: stopped
+
+      - name: Remove keep-client container
+        become: yes
+        ignore_errors: yes
+        community.general.docker_container:
+          name: keep-client
+          state: absent
+
       - name: Run the keep-client container
         become: yes
         docker_container:
@@ -26,23 +40,39 @@
           volumes:
             - "{{ '/home/{0}/keep-client:/mnt'.format(ansible_ssh_user) }}"
             - "{{ '/home/{0}/keep-client/logs:/var/log/keep'.format(ansible_ssh_user) }}"
-          ports: "{{ '{0}:{1}'.format(keep_client.port.local, keep_client.port.container) }}"
-          log_driver: "json-file"
+          ports: 
+            - "{{ '{0}:{1}'.format(keep_client.port.local, keep_client.port.container) }}"
+            - "8081:8080"
+            - "8083:8082"
+          log_driver: loki
           log_options: {
-            "max-size": "10m",
-            "max-file": "3"
+            "loki-url": "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:3100/loki/api/v1/push"
             }
           env:
             LOG_LEVEL: info
             KEEP_ETHEREUM_PASSWORD: "{{ account.password }}"
-            IPFS_LOGGING_FMT: nocolor
-            GOLOG_FILE: /var/log/keep/keep.log
-            GOLOG_TRACING_FILE: /var/log/keep/trace.json
+            # IPFS_LOGGING_FMT: nocolor
+            # GOLOG_FILE: /var/log/keep/keep.log
+            # GOLOG_TRACING_FILE: /var/log/keep/trace.json
       rescue:
         - name: Report the failure and suggested fix
           debug: msg="The keep-client container couldn't be started. Try stop+removing running docker containers b4 retrying."
 
     - block:
+      - name: Stop keep-ecdsa container
+        become: yes
+        ignore_errors: yes
+        community.general.docker_container:
+          name: keep-ecdsa
+          state: stopped
+
+      - name: Remove keep-ecdsa container
+        become: yes
+        ignore_errors: yes
+        community.general.docker_container:
+          name: keep-ecdsa
+          state: absent
+
       - name: Run the keep-ecdsa container
         become: yes
         docker_container:

--- a/roles/firewall/tasks/main.yaml
+++ b/roles/firewall/tasks/main.yaml
@@ -1,4 +1,25 @@
 ---
+- name: Allow ssh communication
+  become: yes
+  ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    
+- name: Set base ufw incoming policy
+  become: yes
+  ufw:
+    direction: incoming
+    policy: deny
+    state: enabled
+
+- name: Set base ufw outgoing policy
+  become: yes
+  ufw:
+    direction: outgoing
+    policy: allow
+    state: enabled
+
 - name: Allow all access to tcp port configured for keep-client
   become: yes
   ufw:

--- a/roles/keep-client/templates/config.toml.jn2
+++ b/roles/keep-client/templates/config.toml.jn2
@@ -25,6 +25,14 @@
   # Override the node’s default addresses announced in the network
   AnnouncedAddresses = ["/ip4/{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}/tcp/{{ keep_client.port.local }}"]
 
+[Metrics]
+    Port = 8080
+    NetworkMetricsTick = 60
+    EthereumMetricsTick = 600
+
+[Diagnostics]
+    Port = 8082
+
 # Storage is encrypted
 [Storage]
   DataDir = "/mnt/persistence"

--- a/roles/keep-ecdsa/templates/config.toml.jn2
+++ b/roles/keep-ecdsa/templates/config.toml.jn2
@@ -32,7 +32,7 @@
 
   Port = {{ keep_ecdsa.port.container }}
   # Override the node’s default addresses announced in the network
-  AnnouncedAddresses = ["/ip4/{{ ip }}/tcp/{{ keep_ecdsa.port.local }}"]
+  AnnouncedAddresses = ["/ip4/{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}/tcp/{{ keep_ecdsa.port.local }}"]
 
 [TSS]
 # Timeout for TSS protocol pre-parameters generation. The value

--- a/roles/monitoring/tasks/main.yaml
+++ b/roles/monitoring/tasks/main.yaml
@@ -1,0 +1,101 @@
+---
+- name: Install curl
+  apt:
+    name: curl
+    state: present
+
+- name: Install docker-compose
+  apt:
+    name: docker-compose
+    state: present
+
+# Upgrade docker-compose
+
+
+### Prometheus Configuration
+- name: Create prometheus directory if it doesn't exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
+    recurse: "yes"
+    mode: "0777"
+  with_items:
+    - "{{ '/home/{0}/prometheus'.format(ansible_ssh_user) }}"
+    - "{{ '/home/{0}/prometheus/prometheus-data'.format(ansible_ssh_user) }}"
+
+- name: Deploy prometheus-data docker-compose config
+  template:
+    owner: "{{ ansible_ssh_user }}"
+    src: prometheus-docker-compose.yml.jn2
+    dest: "{{ '/home/{0}/prometheus/docker-compose.yml'.format(ansible_ssh_user) }}"
+
+- name: Deploy prometheus config
+  template:
+    owner: "{{ ansible_ssh_user }}"
+    src: prometheus.yml.jn2
+    dest: "{{ '/home/{0}/prometheus/prometheus.yml'.format(ansible_ssh_user) }}"
+
+#- name: Tear down existing services
+#  become: true
+#  community.general.docker_compose:
+#    project_src: "{{ '/home/{0}/prometheus'.format(ansible_ssh_user) }}"
+#    state: absent
+
+#- name: Create and start the service defined in prometheus' docker-compose.yml
+#  become: true
+#  community.general.docker_compose:
+#    project_src: "{{ '/home/{0}/prometheus'.format(ansible_ssh_user) }}"
+#    files:
+#    - docker-compose.yml
+#    state: present
+#  register: output
+
+### Loki Configuration
+- name: Create loki directory if it doesn't exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ ansible_ssh_user }}"
+  with_items:
+    - "{{ '/home/{0}/loki'.format(ansible_ssh_user) }}"
+
+- name: Deploy loki docker-compose config
+  template:
+    owner: "{{ ansible_ssh_user }}"
+    src: loki-docker-compose.yml.jn2
+    dest: "{{ '/home/{0}/loki/docker-compose.yml'.format(ansible_ssh_user) }}"
+
+- name: Deploy loki local config
+  template:
+    owner: "{{ ansible_ssh_user }}"
+    src: loki-local-config.yaml.jn2
+    dest: "{{ '/home/{0}/loki/local-config.yaml'.format(ansible_ssh_user) }}"
+
+- name: Install Loki Docker Driver
+  shell: sudo docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+  ignore_errors: yes
+
+- name: Deploy docker daemon for loki
+  template:
+    owner: "{{ ansible_ssh_user }}"
+    src: daemon.json.jn2
+    dest: "{{ '/etc/docker/daemon.json'.format(ansible_ssh_user) }}"
+
+#- name: Tear down existing services
+#  become: true
+#  community.general.docker_compose:
+#    project_src: "{{ '/home/{0}/loki'.format(ansible_ssh_user) }}"
+#    state: absent
+
+#- name: Create and start the service defined in loki's docker-compose.yml
+#  become: true
+#  community.general.docker_compose:
+#    project_src: "{{ '/home/{0}/loki'.format(ansible_ssh_user) }}"
+#    files:
+#    - docker-compose.yml
+#    state: present
+#  register: output
+
+# "Register" fact that monitoring is enabled.
+- 

--- a/roles/monitoring/templates/daemon.json.jn2
+++ b/roles/monitoring/templates/daemon.json.jn2
@@ -1,0 +1,7 @@
+{
+    "debug" : true,
+    "log-driver": "loki",
+    "log-opts": {
+        "loki-url": "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:3100/loki/api/v1/push"
+    }
+}

--- a/roles/monitoring/templates/loki-docker-compose.yml.jn2
+++ b/roles/monitoring/templates/loki-docker-compose.yml.jn2
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ~/loki:/etc/loki

--- a/roles/monitoring/templates/loki-local-config.yaml.jn2
+++ b/roles/monitoring/templates/loki-local-config.yaml.jn2
@@ -1,0 +1,55 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: error
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+    - from: 2018-04-15
+      store: boltdb
+      object_store: filesystem
+      schema: v9
+      index:
+        prefix: index_
+        period: 168h
+
+storage_config:
+  boltdb:
+    directory: /tmp/loki/index
+
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0
+
+table_manager:
+  chunk_tables_provisioning:
+    inactive_read_throughput: 0
+    inactive_write_throughput: 0
+    provisioned_read_throughput: 0
+    provisioned_write_throughput: 0
+  index_tables_provisioning:
+    inactive_read_throughput: 0
+    inactive_write_throughput: 0
+    provisioned_read_throughput: 0
+    provisioned_write_throughput: 0
+  retention_deletes_enabled: false
+  retention_period: 0

--- a/roles/monitoring/templates/prometheus-docker-compose.yml.jn2
+++ b/roles/monitoring/templates/prometheus-docker-compose.yml.jn2
@@ -1,0 +1,34 @@
+prometheus:
+    image: prom/prometheus:latest
+    container_name: monitoring_prometheus
+    restart: unless-stopped
+    volumes:
+      - ~/prometheus:/etc/prometheus/
+      - ~/prometheus/prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+    expose:
+      - 9090
+    ports:
+      - 9090:9090
+    links:
+      - cadvisor:cadvisor
+      - node-exporter:node-exporter
+node-exporter:
+    image: prom/node-exporter:latest
+    container_name: monitoring_node_exporter
+    restart: unless-stopped
+    expose:
+      - 9100
+cadvisor:
+    image: google/cadvisor:latest
+    container_name: monitoring_cadvisor
+    restart: unless-stopped
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    expose:
+      - 8080

--- a/roles/monitoring/templates/prometheus.yml.jn2
+++ b/roles/monitoring/templates/prometheus.yml.jn2
@@ -1,0 +1,56 @@
+# my global config
+global:
+  scrape_interval:     120s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 120s # By default, scrape targets every 15 seconds.
+  scrape_timeout: 50s
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'keep-monitoring'
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  # - "alert.rules"
+  # - "first.rules"
+  # - "second.rules"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 120s
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+         - targets: ['localhost:9090','cadvisor:8080','node-exporter:9100']
+
+  - job_name: 'keep-metrics'
+    scrape_interval: 60s
+    static_configs:
+         - targets: ['{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:8081']
+
+# Alert manager config
+#alerting:
+#  alertmanagers:
+#    - static_configs:
+#      - targets: ["localhost:9093"]
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
New playbook that configures grafana/prometheus in the same manner that MutedTommy outlines in their guide:
https://medium.com/@hr12rtk/keep-random-beacon-node-monitoring-grafana-prometheus-and-loki-4a4b669b31ea

Now steps for setup include:
1. bootstrap_keep
2. bootstrap_monitoring
3. configure_keep
